### PR TITLE
Persist plan visibility

### DIFF
--- a/1.6/Languages/ChineseSimplified (简体中文)/Keyed/Translations.xml
+++ b/1.6/Languages/ChineseSimplified (简体中文)/Keyed/Translations.xml
@@ -103,6 +103,12 @@
   <PlanningExtended.Settings.ArePlansVisible.Label>显示规划</PlanningExtended.Settings.ArePlansVisible.Label>
   <PlanningExtended.Settings.ArePlansVisible.Desc>决定规划标记是否可见。</PlanningExtended.Settings.ArePlansVisible.Desc>
 
+  <PlanningExtended.Settings.StartupPlanVisibility.Label>启动时规划可见性</PlanningExtended.Settings.StartupPlanVisibility.Label>
+  <PlanningExtended.Settings.StartupPlanVisibility.Desc>决定启动时规划的可见性。</PlanningExtended.Settings.StartupPlanVisibility.Desc>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Visible>可见</PlanningExtended.Settings.StartupPlanVisibilities.Visible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Invisible>不可见</PlanningExtended.Settings.StartupPlanVisibilities.Invisible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>上次保存</PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>
+
   <PlanningExtended.Settings.UpgradeOldPlans.Label>升级旧版规划</PlanningExtended.Settings.UpgradeOldPlans.Label>
 
   <PlanningExtended.Settings.ConvertVanillaPlans.Label>从原版规划转换</PlanningExtended.Settings.ConvertVanillaPlans.Label>
@@ -159,4 +165,4 @@
   <PlanningExtended.Direction.DiagonalNW>对角线 (西北)</PlanningExtended.Direction.DiagonalNW>
   <PlanningExtended.Direction.DiagonalNE>对角线 (东北)</PlanningExtended.Direction.DiagonalNE>
 
-</LanguageData> 
+</LanguageData>

--- a/1.6/Languages/English/Keyed/Translations.xml
+++ b/1.6/Languages/English/Keyed/Translations.xml
@@ -100,6 +100,12 @@
   <PlanningExtended.Settings.UseSkipInsteadOfReplaceAsDefault.Label>Use Skip instead of Replace as default</PlanningExtended.Settings.UseSkipInsteadOfReplaceAsDefault.Label>
   <PlanningExtended.Settings.UseSkipInsteadOfReplaceAsDefault.Desc>If enabled, designations are skipped by default. Otherwise, they are replaced.</PlanningExtended.Settings.UseSkipInsteadOfReplaceAsDefault.Desc>
 
+  <PlanningExtended.Settings.StartupPlanVisibility.Label>Startup Plan Visibility</PlanningExtended.Settings.StartupPlanVisibility.Label>
+  <PlanningExtended.Settings.StartupPlanVisibility.Desc>Determines the startup plan visibility.</PlanningExtended.Settings.StartupPlanVisibility.Desc>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Visible>Visible</PlanningExtended.Settings.StartupPlanVisibilities.Visible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Invisible>Invisible</PlanningExtended.Settings.StartupPlanVisibilities.Invisible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>Last Saved</PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>
+
   <PlanningExtended.Settings.ArePlansVisible.Label>Display Plans</PlanningExtended.Settings.ArePlansVisible.Label>
   <PlanningExtended.Settings.ArePlansVisible.Desc>Determines whether plan designations are visible or not.</PlanningExtended.Settings.ArePlansVisible.Desc>
 
@@ -117,7 +123,7 @@
   <PlanningExtended.Shapes.Hexagon>Hexagon</PlanningExtended.Shapes.Hexagon>
   <PlanningExtended.Shapes.Octagon>Octagon</PlanningExtended.Shapes.Octagon>
   <PlanningExtended.Shapes.Ellipse>Ellipse</PlanningExtended.Shapes.Ellipse>
-  
+
   <PlanningExtended.Shapes.Variants.Points>Points</PlanningExtended.Shapes.Variants.Points>
   <PlanningExtended.Shapes.Variants.LineSimple>Line Simple</PlanningExtended.Shapes.Variants.LineSimple>
   <PlanningExtended.Shapes.Variants.LineGrid>Line Grid</PlanningExtended.Shapes.Variants.LineGrid>
@@ -141,9 +147,9 @@
   <PlanningExtended.Shapes.Columns>Columns</PlanningExtended.Shapes.Columns>
   <PlanningExtended.Shapes.Rows>Rows</PlanningExtended.Shapes.Rows>
   <PlanningExtended.Shapes.Cells>Cells</PlanningExtended.Shapes.Cells>
-  
+
   <PlanningExtended.Direction>Direction</PlanningExtended.Direction>
-  
+
   <PlanningExtended.Direction.None>None</PlanningExtended.Direction.None>
   <PlanningExtended.Direction.North>North</PlanningExtended.Direction.North>
   <PlanningExtended.Direction.NorthEast>North East</PlanningExtended.Direction.NorthEast>

--- a/1.6/Languages/German/Keyed/Translations.xml
+++ b/1.6/Languages/German/Keyed/Translations.xml
@@ -103,6 +103,12 @@
   <PlanningExtended.Settings.ArePlansVisible.Label>Pläne anzeigen</PlanningExtended.Settings.ArePlansVisible.Label>
   <PlanningExtended.Settings.ArePlansVisible.Desc>Legt fest, ob Pläne angezeigt werden.</PlanningExtended.Settings.ArePlansVisible.Desc>
 
+  <PlanningExtended.Settings.StartupPlanVisibility.Label>Sichtbarkeit beim Start</PlanningExtended.Settings.StartupPlanVisibility.Label>
+  <PlanningExtended.Settings.StartupPlanVisibility.Desc>Legt die Sichtbarkeit der Pläne beim Start fest.</PlanningExtended.Settings.StartupPlanVisibility.Desc>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Visible>Sichtbar</PlanningExtended.Settings.StartupPlanVisibilities.Visible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Invisible>Unsichtbar</PlanningExtended.Settings.StartupPlanVisibilities.Invisible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>Zuletzt gespeichert</PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>
+
   <PlanningExtended.Settings.UpgradeOldPlans.Label>Alte Pläne upgraden</PlanningExtended.Settings.UpgradeOldPlans.Label>
 
   <PlanningExtended.Settings.ConvertVanillaPlans.Label>Vanilla Pläne konvertieren</PlanningExtended.Settings.ConvertVanillaPlans.Label>

--- a/1.6/Languages/Russian/Keyed/Translations.xml
+++ b/1.6/Languages/Russian/Keyed/Translations.xml
@@ -103,6 +103,12 @@
   <PlanningExtended.Settings.ArePlansVisible.Label>Показывать план</PlanningExtended.Settings.ArePlansVisible.Label>
   <PlanningExtended.Settings.ArePlansVisible.Desc>Определяет, видны ли обозначения плана.</PlanningExtended.Settings.ArePlansVisible.Desc>
 
+  <PlanningExtended.Settings.StartupPlanVisibility.Label>Начальная видимость планов</PlanningExtended.Settings.StartupPlanVisibility.Label>
+  <PlanningExtended.Settings.StartupPlanVisibility.Desc>Определяет видимость планов при запуске.</PlanningExtended.Settings.StartupPlanVisibility.Desc>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Visible>Видимый</PlanningExtended.Settings.StartupPlanVisibilities.Visible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Invisible>Невидимый</PlanningExtended.Settings.StartupPlanVisibilities.Invisible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>Последнее сохранение</PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>
+
   <PlanningExtended.Settings.UpgradeOldPlans.Label>Обновить планы с прошлых версий</PlanningExtended.Settings.UpgradeOldPlans.Label>
 
   <PlanningExtended.Settings.ConvertVanillaPlans.Label>Конвертировать из ванильных планов</PlanningExtended.Settings.ConvertVanillaPlans.Label>

--- a/1.6/Languages/Spanish/Keyed/Translations.xml
+++ b/1.6/Languages/Spanish/Keyed/Translations.xml
@@ -103,6 +103,12 @@
   <PlanningExtended.Settings.ArePlansVisible.Label>Mostrar Planes</PlanningExtended.Settings.ArePlansVisible.Label>
   <PlanningExtended.Settings.ArePlansVisible.Desc>Determina si las designaciones de plan son visibles o no.</PlanningExtended.Settings.ArePlansVisible.Desc>
 
+  <PlanningExtended.Settings.StartupPlanVisibility.Label>Visibilidad inicial de los planes</PlanningExtended.Settings.StartupPlanVisibility.Label>
+  <PlanningExtended.Settings.StartupPlanVisibility.Desc>Determina la visibilidad de los planes al iniciar.</PlanningExtended.Settings.StartupPlanVisibility.Desc>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Visible>Visible</PlanningExtended.Settings.StartupPlanVisibilities.Visible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.Invisible>Invisible</PlanningExtended.Settings.StartupPlanVisibilities.Invisible>
+  <PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>Último guardado</PlanningExtended.Settings.StartupPlanVisibilities.LastSaved>
+
   <PlanningExtended.Settings.UpgradeOldPlans.Label>Actualizar planes antiguos</PlanningExtended.Settings.UpgradeOldPlans.Label>
 
   <PlanningExtended.Settings.ConvertVanillaPlans.Label>Convertir desde planes Vanilla</PlanningExtended.Settings.ConvertVanillaPlans.Label>

--- a/Source/PlanningExtended 1.6/Source/Definitions/StartupPlanVisibility.cs
+++ b/Source/PlanningExtended 1.6/Source/Definitions/StartupPlanVisibility.cs
@@ -1,0 +1,8 @@
+﻿namespace PlanningExtended;
+
+public enum StartupPlanVisibility
+{
+    Visible,
+    Invisible,
+    LastSaved,
+}

--- a/Source/PlanningExtended 1.6/Source/Extensions/StartupPlanVisibilityExtension.cs
+++ b/Source/PlanningExtended 1.6/Source/Extensions/StartupPlanVisibilityExtension.cs
@@ -1,0 +1,16 @@
+using Verse;
+
+namespace PlanningExtended;
+
+internal static class StartupPlanVisibilityExtensions
+{
+    public static string Translate(this StartupPlanVisibility startupPlanVisibility)
+    {
+        return (startupPlanVisibility switch
+        {
+            StartupPlanVisibility.Invisible => "PlanningExtended.Settings.StartupPlanVisibilities.Invisible",
+            StartupPlanVisibility.LastSaved => "PlanningExtended.Settings.StartupPlanVisibilities.LastSaved",
+            _ => "PlanningExtended.Settings.StartupPlanVisibilities.Visible"
+        }).Translate();
+    }
+}

--- a/Source/PlanningExtended 1.6/Source/Plans/Appearances/PlanAppearanceManager.cs
+++ b/Source/PlanningExtended 1.6/Source/Plans/Appearances/PlanAppearanceManager.cs
@@ -144,7 +144,7 @@ namespace PlanningExtended.Plans.Appearances
 
         static PlanAppearance CreatePlanAppearance(PlanDesignationType planDesignationType)
         {
-            return new PlanAppearance(planDesignationType, Settings.GetOpacity(planDesignationType), Settings.GetTextureSet(planDesignationType), Settings.GetIsVisible(planDesignationType));
+            return new PlanAppearance(planDesignationType, Settings.GetOpacity(planDesignationType), Settings.GetTextureSet(planDesignationType), Settings.IsInitiallyVisible(planDesignationType));
         }
     }
 }

--- a/Source/PlanningExtended 1.6/Source/Plans/Appearances/PlanAppearanceManager.cs
+++ b/Source/PlanningExtended 1.6/Source/Plans/Appearances/PlanAppearanceManager.cs
@@ -111,6 +111,8 @@ namespace PlanningExtended.Plans.Appearances
             DetermineVisibility();
 
             VisibilityChanged?.Invoke(PlanVisibility);
+
+            Settings.SetIsVisible(planDesignationType, isVisible);
         }
 
         public static void ToggleIsPlanVisible(PlanDesignationType planDesignationType)
@@ -142,7 +144,7 @@ namespace PlanningExtended.Plans.Appearances
 
         static PlanAppearance CreatePlanAppearance(PlanDesignationType planDesignationType)
         {
-            return new PlanAppearance(planDesignationType, Settings.GetOpacity(planDesignationType), Settings.GetTextureSet(planDesignationType), true);
+            return new PlanAppearance(planDesignationType, Settings.GetOpacity(planDesignationType), Settings.GetTextureSet(planDesignationType), Settings.GetIsVisible(planDesignationType));
         }
     }
 }

--- a/Source/PlanningExtended 1.6/Source/Settings/PlanDesignationSetting.cs
+++ b/Source/PlanningExtended 1.6/Source/Settings/PlanDesignationSetting.cs
@@ -10,16 +10,19 @@ namespace PlanningExtended.Settings
 
         public PlanTextureSet textureSet;
 
+        public bool isVisible;
+
         public PlanDesignationSetting()
         {
 
         }
 
-        public PlanDesignationSetting(float opacity, string color, PlanTextureSet textureSet)
+        public PlanDesignationSetting(float opacity, string color, PlanTextureSet textureSet, bool isVisible)
         {
             this.opacity = opacity;
             this.color = color;
             this.textureSet = textureSet;
+            this.isVisible = isVisible;
         }
 
         public void ExposeData()
@@ -27,6 +30,7 @@ namespace PlanningExtended.Settings
             Scribe_Values.Look(ref opacity, nameof(opacity), 1f);
             Scribe_Values.Look(ref color, nameof(color), "");
             Scribe_Values.Look(ref textureSet, nameof(textureSet), PlanTextureSet.Round);
+            Scribe_Values.Look(ref isVisible, nameof(isVisible), true);
         }
     }
 }

--- a/Source/PlanningExtended 1.6/Source/Settings/PlanningSettings.cs
+++ b/Source/PlanningExtended 1.6/Source/Settings/PlanningSettings.cs
@@ -31,6 +31,8 @@ namespace PlanningExtended.Settings
 
         public string paintPlanColor = Default.PaintPlanColor;
 
+        public StartupPlanVisibility startupPlanVisibility = Default.StartupPlanVisibility;
+
         public override void ExposeData()
         {
             Scribe_Values.Look(ref useUndoRedo, nameof(useUndoRedo), Default.UseUndoRedo);
@@ -43,6 +45,7 @@ namespace PlanningExtended.Settings
             Scribe_Values.Look(ref useSkipInsteadOfReplaceAsDefault, nameof(useSkipInsteadOfReplaceAsDefault), Default.UseSkipInsteadOfReplaceAsDefault);
             Scribe_Values.Look(ref paintPlanColor, nameof(paintPlanColor), Default.PaintPlanColor);
             //Scribe_Values.Look(ref alwaysGrabBottom, nameof(alwaysGrabBottom), false);
+            Scribe_Values.Look(ref startupPlanVisibility, nameof(startupPlanVisibility), Default.StartupPlanVisibility);
 
             Scribe_Collections.Look(ref lastLoadedPlans, nameof(lastLoadedPlans));
             Scribe_Collections.Look(ref planDesignationSettings, nameof(planDesignationSettings), LookMode.Value, LookMode.Deep);
@@ -121,9 +124,24 @@ namespace PlanningExtended.Settings
                 Write();
         }
 
-        public bool GetIsVisible(PlanDesignationType planDesignationType)
+        public bool IsInitiallyVisible(PlanDesignationType planDesignationType)
         {
-            return planDesignationSettings.TryGetValue(planDesignationType, out PlanDesignationSetting planDesignationSetting) ? planDesignationSetting.isVisible : true;
+            return startupPlanVisibility switch
+            {
+                StartupPlanVisibility.Invisible => false,
+                StartupPlanVisibility.LastSaved => planDesignationSettings.GetValueOrDefault(planDesignationType)?.isVisible ?? true,
+                _ => true,
+            };
+        }
+
+        public void SetStartupPlanVisibility(StartupPlanVisibility startupPlanVisibility, bool autoSave = true)
+        {
+            this.startupPlanVisibility = startupPlanVisibility;
+
+            if (autoSave)
+            {
+                Write();
+            }
         }
 
         public void AddLastLoadedPlan(string planName, bool autoSave = true)
@@ -191,6 +209,8 @@ namespace PlanningExtended.Settings
             public const bool UseSkipInsteadOfReplaceAsDefault = false;
 
             public const string PaintPlanColor = ColorDefinitions.DefaultColorName;
+
+            public const StartupPlanVisibility StartupPlanVisibility = PlanningExtended.StartupPlanVisibility.Visible;
         }
     }
 }

--- a/Source/PlanningExtended 1.6/Source/Settings/PlanningSettings.cs
+++ b/Source/PlanningExtended 1.6/Source/Settings/PlanningSettings.cs
@@ -112,6 +112,20 @@ namespace PlanningExtended.Settings
             return planDesignationSettings.TryGetValue(planDesignationType, out PlanDesignationSetting planDesignationSetting) ? planDesignationSetting.textureSet : PlanTextureSet.Round;
         }
 
+        public void SetIsVisible(PlanDesignationType planDesignationType, bool isVisible, bool autoSave = true)
+        {
+            foreach (PlanDesignationSetting planDesignationSetting in GetPlanDesignationSettings(planDesignationType))
+                planDesignationSetting.isVisible = isVisible;
+
+            if (autoSave)
+                Write();
+        }
+
+        public bool GetIsVisible(PlanDesignationType planDesignationType)
+        {
+            return planDesignationSettings.TryGetValue(planDesignationType, out PlanDesignationSetting planDesignationSetting) ? planDesignationSetting.isVisible : true;
+        }
+
         public void AddLastLoadedPlan(string planName, bool autoSave = true)
         {
             lastLoadedPlans.RemoveAll(p => p == planName);
@@ -139,7 +153,7 @@ namespace PlanningExtended.Settings
 
             foreach (PlanDesignationType planDesignationType in PlanDesignationUtilities.GetPlanDesignationTypes())
                 if (!planDesignationSettings.ContainsKey(planDesignationType))
-                    planDesignationSettings[planDesignationType] = new PlanDesignationSetting(1f, "", PlanTextureSet.Round);
+                    planDesignationSettings[planDesignationType] = new PlanDesignationSetting(1f, "", PlanTextureSet.Round, true);
         }
 
         IEnumerable<PlanDesignationSetting> GetPlanDesignationSettings(PlanDesignationType planDesignationType)

--- a/Source/PlanningExtended 1.6/Source/Settings/SettingsGuiUtilities.cs
+++ b/Source/PlanningExtended 1.6/Source/Settings/SettingsGuiUtilities.cs
@@ -1,12 +1,22 @@
-﻿using PlanningExtended.Plans.Converters;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using PlanningExtended.Plans.Converters;
 using PlanningExtended.Updates;
 using UnityEngine;
 using Verse;
+using static PlanningExtended.Settings.PlanningSettings;
 
 namespace PlanningExtended.Settings
 {
     public static class SettingsGuiUtilities
     {
+        private static readonly List<FloatMenuOption> startupPlanVisibilityOptions = [
+            ..Enum.GetValues(typeof(StartupPlanVisibility)).Cast<StartupPlanVisibility>().Select(
+                v => new FloatMenuOption(v.Translate(), () => PlanningMod.Settings.SetStartupPlanVisibility(v))
+            )
+        ];
+
         public static void DisplaySettings(PlanningSettings settings, Rect inRect)
         {
             float margin = 16f;
@@ -34,16 +44,21 @@ namespace PlanningExtended.Settings
             settings.maxUndoOperations = listingStandard.SliderLabel(settings.maxUndoOperations, 5, 50, () => "PlanningExtended.Settings.MaxUndoRedoOperations.Label".Translate() + " (5 - 50): " + settings.maxUndoOperations);
 
             listingStandard.CheckboxLabeled("PlanningExtended.Settings.DisplayCutDesignator.Label".Translate(), ref settings.displayCutDesignator, "PlanningExtended.Settings.DisplayCutDesignator.Desc".Translate());
-            
+
             listingStandard.CheckboxLabeled("PlanningExtended.Settings.DisplayChangePlanAppearanceDesignator.Label".Translate(), ref settings.displayChangePlanAppearanceDesignator, "PlanningExtended.Settings.DisplayChangePlanAppearanceDesignator.Desc".Translate());
-            
+
             listingStandard.CheckboxLabeled("PlanningExtended.Settings.DisplayTogglePlanVisibilityDesignator.Label".Translate(), ref settings.displayTogglePlanVisibilityDesignator, "PlanningExtended.Settings.DisplayTogglePlanVisibilityDesignator.Desc".Translate());
-            
+
             listingStandard.CheckboxLabeled("PlanningExtended.Settings.UseCtrlForColorDialog.Label".Translate(), ref settings.useCtrlForColorDialog, "PlanningExtended.Settings.UseCtrlForColorDialog.Desc".Translate());
-            
+
             listingStandard.CheckboxLabeled("PlanningExtended.Settings.ArePlansPersistent.Label".Translate(), ref settings.areDesignationsPersistent, "PlanningExtended.Settings.ArePlansPersistent.Desc".Translate());
 
             listingStandard.CheckboxLabeled("PlanningExtended.Settings.UseSkipInsteadOfReplaceAsDefault.Label".Translate(), ref settings.useSkipInsteadOfReplaceAsDefault, "PlanningExtended.Settings.UseSkipInsteadOfReplaceAsDefault.Desc".Translate());
+
+            if (listingStandard.ButtonTextLabeled("PlanningExtended.Settings.StartupPlanVisibility.Label".Translate(), settings.startupPlanVisibility.Translate(), tooltip: "PlanningExtended.Settings.StartupPlanVisibility.Desc".Translate()))
+            {
+                Find.WindowStack.Add(new FloatMenu(startupPlanVisibilityOptions));
+            }
 
             //listingStandard.EndSubSection();
 


### PR DESCRIPTION
This PR make the plan visibility property persistent. I am not sure why the visibility property is not saved in the first place. Treating the visibility property like the other plan properties seems like a reasonable choice.

- Closes #74.
- Closes #114.